### PR TITLE
Make use of Safe transaction bundling to group payout claims

### DIFF
--- a/src/components/Modals/PayoutModal/ModalBody.tsx
+++ b/src/components/Modals/PayoutModal/ModalBody.tsx
@@ -1,0 +1,27 @@
+import React, { ReactElement } from "react";
+import { Text } from "@gnosis.pm/safe-react-components";
+import { formatUnits } from "ethers/utils";
+import { PayoutInfo, Token } from "../../../typings";
+import { useTokens } from "../../../contexts/ColonyContext";
+
+const ModalBody = ({ payouts }: { payouts: PayoutInfo[] }): ReactElement => {
+  const tokens = useTokens();
+
+  return (
+    <>
+      <Text size="md">{`You may claim or waive your share of the following ${
+        payouts.length ? `${payouts.length} payouts` : "payout"
+      } :`}</Text>
+      {payouts.map(payout => {
+        const token = tokens.find(({ address }) => address === payout.tokenAddress) as Token;
+        return (
+          <Text size="md" key={payout.blockTimestamp.toString()}>{`${formatUnits(payout.amount, token?.decimals)} ${
+            token?.symbol
+          }`}</Text>
+        );
+      })}
+    </>
+  );
+};
+
+export default ModalBody;

--- a/src/components/Modals/PayoutModal/index.tsx
+++ b/src/components/Modals/PayoutModal/index.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement, useCallback } from "react";
 import { GenericModal, Text } from "@gnosis.pm/safe-react-components";
-import { formatUnits } from "ethers/utils";
 import ModalFooter from "./ModalFooter";
 import { Token, PayoutInfo } from "../../../typings";
 import { useAppsSdk, useSafeInfo } from "../../../contexts/SafeContext";
@@ -11,12 +10,12 @@ import waivePayoutTxs from "../../../utils/transactions/rewards/waivePayout";
 const PayoutModal = ({
   isOpen,
   setIsOpen,
-  payout,
+  payouts,
   token,
 }: {
   isOpen: boolean;
   setIsOpen: Function;
-  payout: PayoutInfo;
+  payouts: PayoutInfo[];
   token: Token;
 }): ReactElement | null => {
   const safeInfo = useSafeInfo();
@@ -25,25 +24,21 @@ const PayoutModal = ({
 
   const claimPayout = useCallback(async () => {
     if (colonyClient && safeInfo?.safeAddress) {
-      const txs = await claimPayoutTxs(colonyClient, safeInfo.safeAddress, payout);
+      const txs = await Promise.all(payouts.map(payout => claimPayoutTxs(colonyClient, safeInfo.safeAddress, payout)));
       appsSdk.sendTransactions(txs);
     }
-  }, [colonyClient, payout, safeInfo, appsSdk]);
+  }, [colonyClient, payouts, safeInfo, appsSdk]);
 
   const waivePayout = useCallback(async () => {
     if (colonyClient && safeInfo?.safeAddress) {
-      const txs = await waivePayoutTxs(colonyClient, safeInfo.safeAddress, payout);
+      const txs = await Promise.all(payouts.map(payout => waivePayoutTxs(colonyClient, safeInfo.safeAddress, payout)));
       appsSdk.sendTransactions(txs);
     }
-  }, [colonyClient, payout, safeInfo, appsSdk]);
+  }, [colonyClient, payouts, safeInfo, appsSdk]);
 
   const modalBody = (
     <>
-      <Text size="md">
-        {`You may claim or waive your share of the ${formatUnits(payout.amount, token?.decimals)} ${
-          token.symbol
-        } payout.`}
-      </Text>
+      <Text size="md">{`You may claim or waive your share of the ${payouts.length} ${token.symbol} payout(s).`}</Text>
     </>
   );
 

--- a/src/components/Modals/PayoutModal/index.tsx
+++ b/src/components/Modals/PayoutModal/index.tsx
@@ -1,22 +1,21 @@
 import React, { ReactElement, useCallback } from "react";
-import { GenericModal, Text } from "@gnosis.pm/safe-react-components";
+import { GenericModal } from "@gnosis.pm/safe-react-components";
 import ModalFooter from "./ModalFooter";
-import { Token, PayoutInfo } from "../../../typings";
+import { PayoutInfo } from "../../../typings";
 import { useAppsSdk, useSafeInfo } from "../../../contexts/SafeContext";
 import { useColonyClient } from "../../../contexts/ColonyContext";
 import claimPayoutTxs from "../../../utils/transactions/rewards/claimPayout";
 import waivePayoutTxs from "../../../utils/transactions/rewards/waivePayout";
+import ModalBody from "./ModalBody";
 
 const PayoutModal = ({
   isOpen,
   setIsOpen,
   payouts,
-  token,
 }: {
   isOpen: boolean;
   setIsOpen: Function;
   payouts: PayoutInfo[];
-  token: Token;
 }): ReactElement | null => {
   const safeInfo = useSafeInfo();
   const appsSdk = useAppsSdk();
@@ -36,12 +35,6 @@ const PayoutModal = ({
     }
   }, [colonyClient, payouts, safeInfo, appsSdk]);
 
-  const modalBody = (
-    <>
-      <Text size="md">{`You may claim or waive your share of the ${payouts.length} ${token.symbol} payout(s).`}</Text>
-    </>
-  );
-
   const modalFooter = (
     <ModalFooter cancelText="Waive" okText="Claim" handleCancel={() => waivePayout()} handleOk={() => claimPayout()} />
   );
@@ -50,8 +43,8 @@ const PayoutModal = ({
   return (
     <GenericModal
       onClose={() => setIsOpen(false)}
-      title={`${token.symbol} Payout`}
-      body={modalBody}
+      title="Claim Payouts"
+      body={<ModalBody payouts={payouts} />}
       footer={modalFooter}
     />
   );

--- a/src/components/Modals/PayoutModal/index.tsx
+++ b/src/components/Modals/PayoutModal/index.tsx
@@ -30,7 +30,7 @@ const PayoutModal = ({
 
   const waivePayout = useCallback(async () => {
     if (colonyClient && safeInfo?.safeAddress) {
-      const txs = await Promise.all(payouts.map(payout => waivePayoutTxs(colonyClient, safeInfo.safeAddress, payout)));
+      const txs = await waivePayoutTxs(colonyClient, safeInfo.safeAddress, payouts.length);
       appsSdk.sendTransactions(txs);
     }
   }, [colonyClient, payouts, safeInfo, appsSdk]);

--- a/src/components/Modals/TokenModal/index.tsx
+++ b/src/components/Modals/TokenModal/index.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement, useState, useCallback } from "react";
 import { ModalFooterConfirmation, GenericModal } from "@gnosis.pm/safe-react-components";
 import { Box, Tab, Tabs } from "@material-ui/core";
 import { ColonyRole, getMoveFundsPermissionProofs } from "@colony/colony-js";
+import { parseUnits } from "ethers/utils";
 import { Token, PermissionProof, Domain } from "../../../typings";
 import SendTokensBody from "./SendTokensBody";
 import MoveTokensBody from "./MoveTokensBody";
@@ -76,13 +77,13 @@ const TokenModal = ({
         fromChildSkillIndex,
         toChildSkillIndex,
         token.address,
-        amount,
+        parseUnits(amount, token.decimals),
         fromPotId,
         toPotId,
       );
       appSdk.sendTransactions(txs);
     }
-  }, [amount, appSdk, client, domain.fundingPotId, safeInfo, toDomain.fundingPotId, token.address]);
+  }, [amount, appSdk, client, domain.fundingPotId, safeInfo, toDomain.fundingPotId, token.address, token.decimals]);
 
   const sendTokens = useCallback(() => {
     if (client && adminPermissionProof && paymentClientProof) {
@@ -101,13 +102,23 @@ const TokenModal = ({
         callerChildSkillIndex,
         recipient,
         token.address,
-        amount,
+        parseUnits(amount, token.decimals),
         domainId,
         skillId,
       );
       appSdk.sendTransactions(txs);
     }
-  }, [adminPermissionProof, amount, appSdk, client, domain, paymentClientProof, recipient, token.address]);
+  }, [
+    adminPermissionProof,
+    amount,
+    appSdk,
+    client,
+    domain,
+    paymentClientProof,
+    recipient,
+    token.address,
+    token.decimals,
+  ]);
 
   const modalTitle = `${token.symbol}`;
 

--- a/src/components/Modals/TokenModal/index.tsx
+++ b/src/components/Modals/TokenModal/index.tsx
@@ -75,14 +75,14 @@ const TokenModal = ({
         fromPermissionDomainId,
         fromChildSkillIndex,
         toChildSkillIndex,
-        "0",
+        token.address,
         amount,
         fromPotId,
         toPotId,
       );
       appSdk.sendTransactions(txs);
     }
-  }, [amount, appSdk, client, domain.fundingPotId, safeInfo, toDomain.fundingPotId]);
+  }, [amount, appSdk, client, domain.fundingPotId, safeInfo, toDomain.fundingPotId, token.address]);
 
   const sendTokens = useCallback(() => {
     if (client && adminPermissionProof && paymentClientProof) {

--- a/src/components/PayoutList/PayoutRow.tsx
+++ b/src/components/PayoutList/PayoutRow.tsx
@@ -14,10 +14,10 @@ const PayoutRow = ({ payouts }: { payouts: PayoutInfo[] }) => {
     return payoutTotal.add(amount);
   }, Zero);
 
-  if (!payoutToken) return null;
+  if (payouts.length === 0) return null;
   return (
     <>
-      <PayoutModal isOpen={isOpen} setIsOpen={setIsOpen} payouts={payouts} token={payoutToken} />
+      <PayoutModal isOpen={isOpen} setIsOpen={setIsOpen} payouts={payouts} />
       <TableRow onClick={() => setIsOpen(true)}>
         <TableCell>{payoutToken?.symbol || payouts[0].tokenAddress}</TableCell>
         <TableCell align="right">{formatUnits(totalAmount, payoutToken?.decimals)}</TableCell>

--- a/src/components/PayoutList/PayoutRow.tsx
+++ b/src/components/PayoutList/PayoutRow.tsx
@@ -1,21 +1,26 @@
 import React, { useState } from "react";
-import { formatUnits } from "ethers/utils";
+import { formatUnits, BigNumber } from "ethers/utils";
 import { TableRow, TableCell } from "@material-ui/core";
+import { Zero } from "ethers/constants";
 import PayoutModal from "../Modals/PayoutModal";
 import { useToken } from "../../contexts/ColonyContext";
 import { PayoutInfo } from "../../typings";
 
-const PayoutRow = ({ payout }: { payout: PayoutInfo }) => {
-  const payoutToken = useToken(payout.tokenAddress);
+const PayoutRow = ({ payouts }: { payouts: PayoutInfo[] }) => {
+  const payoutToken = useToken(payouts[0].tokenAddress);
   const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  const totalAmount: BigNumber = payouts.reduce((payoutTotal: BigNumber, { amount }) => {
+    return payoutTotal.add(amount);
+  }, Zero);
 
   if (!payoutToken) return null;
   return (
     <>
-      <PayoutModal isOpen={isOpen} setIsOpen={setIsOpen} payout={payout} token={payoutToken} />
+      <PayoutModal isOpen={isOpen} setIsOpen={setIsOpen} payouts={payouts} token={payoutToken} />
       <TableRow onClick={() => setIsOpen(true)}>
-        <TableCell>{payoutToken?.symbol || payout.tokenAddress}</TableCell>
-        <TableCell align="right">{formatUnits(payout.amount, payoutToken?.decimals)}</TableCell>
+        <TableCell>{payoutToken?.symbol || payouts[0].tokenAddress}</TableCell>
+        <TableCell align="right">{formatUnits(totalAmount, payoutToken?.decimals)}</TableCell>
       </TableRow>
     </>
   );

--- a/src/components/PayoutList/Sidebar.tsx
+++ b/src/components/PayoutList/Sidebar.tsx
@@ -1,17 +1,23 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { ColonyRole } from "@colony/colony-js";
-import { Text } from "@gnosis.pm/safe-react-components";
+import { Text, Button } from "@gnosis.pm/safe-react-components";
 import { BigNumber } from "ethers/utils";
-import { useHasDomainPermission, useRewardInverse } from "../../contexts/ColonyContext";
+import { useHasDomainPermission, useRewardInverse, useActivePayouts } from "../../contexts/ColonyContext";
 import { useSafeInfo } from "../../contexts/SafeContext";
 import SetRewardsModal from "../Modals/SetRewardsModal";
 import TokenLockingModal from "../Modals/TokenLockingModal";
+import PayoutModal from "../Modals/PayoutModal";
 
 const PayoutSidebar = () => {
   const safeInfo = useSafeInfo();
   const rewardsInverse = useRewardInverse();
+  const activePayouts = useActivePayouts().sort((a, b) => {
+    if (a.tokenAddress === b.tokenAddress) return 0;
+    return a.tokenAddress.toUpperCase() > b.tokenAddress.toUpperCase() ? 1 : -1;
+  });
   const hasRootPermission = useHasDomainPermission(safeInfo?.safeAddress, 1, ColonyRole.Root);
 
+  const [isOpen, setIsOpen] = useState<boolean>(false);
   const rewardsPercentage = useMemo(() => new BigNumber(100).div(rewardsInverse), [rewardsInverse]);
 
   return (
@@ -20,6 +26,10 @@ const PayoutSidebar = () => {
       <SetRewardsModal disabled={!hasRootPermission} />
       <TokenLockingModal lock />
       <TokenLockingModal />
+      <PayoutModal isOpen={isOpen} setIsOpen={setIsOpen} payouts={activePayouts} />
+      <Button size="md" color="primary" onClick={() => setIsOpen(!isOpen)} disabled={activePayouts.length === 0}>
+        Claim all payouts
+      </Button>
     </>
   );
 };

--- a/src/components/PayoutList/index.tsx
+++ b/src/components/PayoutList/index.tsx
@@ -9,6 +9,17 @@ import Table from "../common/StyledTable";
 
 import { useSafeInfo } from "../../contexts/SafeContext";
 import { useActivePayouts, useHasDomainPermission } from "../../contexts/ColonyContext";
+import { PayoutInfo } from "../../typings";
+
+type GroupedPayouts = { [tokenAddress: string]: PayoutInfo[] };
+
+const groupPayouts = (payouts: PayoutInfo[]): GroupedPayouts => {
+  return payouts.reduce((accumulator: GroupedPayouts, payout: PayoutInfo) => {
+    accumulator[payout.tokenAddress] = accumulator[payout.tokenAddress] || [];
+    accumulator[payout.tokenAddress].push(payout);
+    return accumulator;
+  }, {});
+};
 
 const PayoutList = () => {
   const safeInfo = useSafeInfo();
@@ -16,9 +27,13 @@ const PayoutList = () => {
   const hasRootPermission = useHasDomainPermission(safeInfo?.safeAddress, 1, ColonyRole.Root);
 
   const payoutList = useMemo(
-    () => activePayouts.map(payout => <PayoutRow key={payout.blockTimestamp.toString()} payout={payout} />),
+    () =>
+      Object.entries(groupPayouts(activePayouts)).map(([tokenAddress, payouts]) => (
+        <PayoutRow key={tokenAddress} payouts={payouts} />
+      )),
     [activePayouts],
   );
+
   return (
     <Table>
       <TableBody>

--- a/src/contexts/ColonyContext/hooks.ts
+++ b/src/contexts/ColonyContext/hooks.ts
@@ -5,6 +5,7 @@ import { TokenInfo } from "@colony/colony-js/lib/clients/TokenClient";
 import { BigNumber, BigNumberish } from "ethers/utils";
 import { getPermissionProofs } from "@colony/colony-js/lib/clients/Colony/extensions/commonExtensions";
 import { Zero, MaxUint256 } from "ethers/constants";
+import { ExtendedTokenLocking } from "@colony/colony-js/lib/clients/TokenLockingClient";
 import { Domain, PermissionProof, MoveFundsBetweenPotsProof, Token, PayoutInfo } from "../../typings";
 import userHasDomainRole from "../../utils/colony/userHasDomainRole";
 import { useColonyContext } from "./ColonyContext";
@@ -14,6 +15,19 @@ import getActivePayouts from "../../utils/colony/getColonyPayouts";
 export const useColonyClient = (): ColonyClient | undefined => {
   const { colonyClient } = useColonyContext();
   return colonyClient;
+};
+
+export const useTokenLockingClient = (): ExtendedTokenLocking | undefined => {
+  const colonyClient = useColonyClient();
+  const [tokenLockingClient, setTokenLockingClient] = useState<ExtendedTokenLocking>();
+
+  useEffect(() => {
+    if (colonyClient) {
+      colonyClient.networkClient.getTokenLockingClient().then(client => setTokenLockingClient(client));
+    }
+  }, [colonyClient]);
+
+  return tokenLockingClient;
 };
 
 export const useSetColony = (): Function => {

--- a/src/contexts/ColonyContext/index.ts
+++ b/src/contexts/ColonyContext/index.ts
@@ -14,4 +14,5 @@ export {
   useSetColony,
   useTokens,
   useToken,
+  useTokenLockingClient,
 } from "./hooks";

--- a/src/typings/index.ts
+++ b/src/typings/index.ts
@@ -31,14 +31,6 @@ export type PayoutInfo = {
   reputationState: string;
   tokenAddress: string;
   totalTokens: BigNumber;
-  0: string;
-  1: BigNumber;
-  2: BigNumber;
-  3: BigNumber;
-  4: string;
-  5: BigNumber;
-  6?: BigNumber; // These two parameters are not returned by colonies below V4
-  7?: boolean;
   amountRemaining?: BigNumber;
   finalized?: boolean;
 };

--- a/src/utils/colony/getColonyPayouts.ts
+++ b/src/utils/colony/getColonyPayouts.ts
@@ -32,7 +32,25 @@ const getActivePayouts = async (client: ColonyClient): Promise<PayoutInfo[]> => 
 
   const activePayouts = startedPayouts.filter(payoutId => !endedPayouts.includes(payoutId));
   return Promise.all(
-    activePayouts.map(async payoutId => ({ id: payoutId, ...(await client.getRewardPayoutInfo(payoutId)) })),
+    activePayouts.map(async payoutId => {
+      const {
+        amount,
+        blockTimestamp,
+        colonyWideReputation,
+        reputationState,
+        tokenAddress,
+        totalTokens,
+      } = await client.getRewardPayoutInfo(payoutId);
+      return {
+        id: payoutId,
+        amount,
+        blockTimestamp,
+        colonyWideReputation,
+        reputationState,
+        tokenAddress,
+        totalTokens,
+      };
+    }),
   );
 };
 

--- a/src/utils/colony/getColonyTokensInfo.ts
+++ b/src/utils/colony/getColonyTokensInfo.ts
@@ -1,30 +1,32 @@
 import { getTokenClient, ColonyClient } from "@colony/colony-js";
 import { AddressZero } from "ethers/constants";
+import { Provider } from "ethers/providers";
 import getColonyTokens from "./getColonyTokens";
 import { Token } from "../../typings";
+
+const getTokenInfo = async (provider: Provider, tokenAddress: string): Promise<Token | undefined> => {
+  if (tokenAddress === AddressZero) {
+    return {
+      address: AddressZero,
+      name: "Ether",
+      symbol: "ETH",
+      decimals: 18,
+    };
+  }
+  try {
+    return {
+      address: tokenAddress,
+      ...(await getTokenClient(tokenAddress, provider).getTokenInfo()),
+    };
+  } catch (e) {
+    return undefined;
+  }
+};
 
 const getColonyTokensInfo = async (colonyClient: ColonyClient): Promise<Token[]> => {
   const tokenAddresses = await getColonyTokens(colonyClient);
   const tokens: (Token | undefined)[] = await Promise.all(
-    tokenAddresses.map(async (tokenAddress: string) => {
-      if (tokenAddress === AddressZero) {
-        return {
-          address: AddressZero,
-          name: "Ether",
-          symbol: "ETH",
-          decimals: 18,
-        };
-      }
-      try {
-        return {
-          address: tokenAddress,
-          ...(await getTokenClient(tokenAddress, colonyClient.provider).getTokenInfo()),
-        };
-      } catch (e) {
-        console.log(e);
-        return undefined;
-      }
-    }),
+    tokenAddresses.map(async (tokenAddress: string) => getTokenInfo(colonyClient.provider, tokenAddress)),
   );
 
   return tokens.filter(token => typeof token !== "undefined") as Token[];

--- a/src/utils/colony/getReputationProof.ts
+++ b/src/utils/colony/getReputationProof.ts
@@ -1,8 +1,38 @@
 import { ColonyClient } from "@colony/colony-js";
+import { bigNumberify, BigNumberish } from "ethers/utils";
+import { ReputationOracleResponse } from "@colony/colony-js/lib/clients/Colony/types";
 
-const getReputationProof = async (colonyClient: ColonyClient, userAddress: string) => {
+async function getReputation(
+  client: ColonyClient,
+  skillId: BigNumberish,
+  address: string,
+  customRootHash?: string,
+): Promise<ReputationOracleResponse> {
+  const { network, reputationOracleEndpoint } = client.networkClient;
+
+  const skillIdString = bigNumberify(skillId).toString();
+
+  const rootHash = customRootHash || (await client.networkClient.getReputationRootHash());
+
+  const response = await fetch(
+    `${reputationOracleEndpoint}/${network}/${rootHash}/${client.address}/${skillIdString}/${address}`,
+  );
+
+  const result = await response.json();
+
+  return {
+    ...result,
+    reputationAmount: bigNumberify(result.reputationAmount || 0),
+  };
+}
+
+const getReputationProof = async (
+  colonyClient: ColonyClient,
+  userAddress: string,
+  reputationRootHash?: string,
+): Promise<ReputationOracleResponse> => {
   const { skillId } = await colonyClient.getDomain(1);
-  return colonyClient.getReputation(skillId, userAddress);
+  return getReputation(colonyClient, skillId, userAddress, reputationRootHash);
 };
 
 export default getReputationProof;

--- a/src/utils/transactions/moveTokens.ts
+++ b/src/utils/transactions/moveTokens.ts
@@ -8,7 +8,7 @@ const moveTokenTxs = (
   fromChildSkillIndex: BigNumber,
   toChildSkillIndex: BigNumber,
   token: string,
-  amount: string,
+  amount: BigNumber,
   fromPot: BigNumber,
   toPot: BigNumber,
 ): Transaction[] => {

--- a/src/utils/transactions/rewards/claimPayout.ts
+++ b/src/utils/transactions/rewards/claimPayout.ts
@@ -20,6 +20,24 @@ const bnSqrt = (bn: BigNumber, isGreater?: boolean) => {
   return b;
 };
 
+const calculateSquareRoots = (
+  amount: BigNumber,
+  balance: BigNumber,
+  totalTokens: BigNumber,
+  reputationAmount: BigNumber,
+  totalReputation: BigNumber,
+) => {
+  const squareRoots: BigNumber[] = [Zero, Zero, Zero, Zero, Zero, Zero, Zero];
+  squareRoots[0] = bnSqrt(reputationAmount);
+  squareRoots[1] = bnSqrt(balance);
+  squareRoots[2] = bnSqrt(totalReputation, true);
+  squareRoots[3] = bnSqrt(totalTokens, true);
+  squareRoots[4] = bnSqrt(squareRoots[0].mul(squareRoots[1]));
+  squareRoots[5] = bnSqrt(squareRoots[2].mul(squareRoots[3]), true);
+  squareRoots[6] = bnSqrt(amount);
+  return squareRoots;
+};
+
 const claimPayoutTxs = async (
   colonyClient: ColonyClient,
   userAddress: string,
@@ -32,14 +50,7 @@ const claimPayoutTxs = async (
   const tokenLockingClient = await colonyClient.networkClient.getTokenLockingClient();
   const { balance } = await tokenLockingClient.getUserLock(payout.tokenAddress, userAddress);
 
-  const squareRoots: BigNumber[] = [Zero, Zero, Zero, Zero, Zero, Zero, Zero];
-  squareRoots[0] = bnSqrt(reputationAmount);
-  squareRoots[1] = bnSqrt(balance);
-  squareRoots[2] = bnSqrt(colonyWideReputation, true);
-  squareRoots[3] = bnSqrt(totalTokens, true);
-  squareRoots[4] = bnSqrt(squareRoots[0].mul(squareRoots[1]));
-  squareRoots[5] = bnSqrt(squareRoots[2].mul(squareRoots[3]), true);
-  squareRoots[6] = bnSqrt(amount);
+  const squareRoots = calculateSquareRoots(amount, balance, totalTokens, reputationAmount, colonyWideReputation);
 
   const txs: Transaction[] = [];
 

--- a/src/utils/transactions/rewards/claimPayout.ts
+++ b/src/utils/transactions/rewards/claimPayout.ts
@@ -44,8 +44,12 @@ const claimPayoutTxs = async (
   payout: PayoutInfo,
 ): Promise<Transaction[]> => {
   const colonyInterface: Interface = colonyClient.interface;
-  const { id, amount, totalTokens, colonyWideReputation } = payout;
-  const { key, value, branchMask, siblings, reputationAmount } = await getReputationProof(colonyClient, userAddress);
+  const { id, amount, totalTokens, colonyWideReputation, reputationState } = payout;
+  const { key, value, branchMask, siblings, reputationAmount } = await getReputationProof(
+    colonyClient,
+    userAddress,
+    reputationState,
+  );
 
   const tokenLockingClient = await colonyClient.networkClient.getTokenLockingClient();
   const { balance } = await tokenLockingClient.getUserLock(payout.tokenAddress, userAddress);

--- a/src/utils/transactions/rewards/claimPayout.ts
+++ b/src/utils/transactions/rewards/claimPayout.ts
@@ -52,7 +52,7 @@ const claimPayoutTxs = async (
   );
 
   const tokenLockingClient = await colonyClient.networkClient.getTokenLockingClient();
-  const { balance } = await tokenLockingClient.getUserLock(payout.tokenAddress, userAddress);
+  const { balance } = await tokenLockingClient.getUserLock(await colonyClient.getToken(), userAddress);
 
   const squareRoots = calculateSquareRoots(amount, balance, totalTokens, reputationAmount, colonyWideReputation);
 

--- a/src/utils/transactions/rewards/waivePayout.ts
+++ b/src/utils/transactions/rewards/waivePayout.ts
@@ -1,18 +1,22 @@
 import { ColonyClient } from "@colony/colony-js";
-import { Transaction, PayoutInfo } from "../../../typings";
+import { Transaction } from "../../../typings";
 
 const waivePayoutTxs = async (
   colonyClient: ColonyClient,
   userAddress: string,
-  payout: PayoutInfo,
+  payoutsWaived: number,
 ): Promise<Transaction[]> => {
   const tokenLockingClient = await colonyClient.networkClient.getTokenLockingClient();
-  const { lockCount } = await tokenLockingClient.getUserLock(payout.tokenAddress, userAddress);
+  const nativeTokenAddress = await colonyClient.getToken();
+  const { lockCount } = await tokenLockingClient.getUserLock(nativeTokenAddress, userAddress);
 
   const txs: Transaction[] = [];
 
   txs.push({
-    data: tokenLockingClient.interface.functions.incrementLockCounterTo.encode([payout.tokenAddress, lockCount.add(1)]),
+    data: tokenLockingClient.interface.functions.incrementLockCounterTo.encode([
+      nativeTokenAddress,
+      lockCount.add(payoutsWaived),
+    ]),
     to: tokenLockingClient.address,
     value: 0,
   });


### PR DESCRIPTION
Changelog:

- Added the ability to query the user's reputation using a previous reputation state root hash
- Payouts are now grouped by the payout token to be claimed or waived as a group.
- sidebar now has a new modal to claim all payouts (regardless of token)
- Rewards screen now shows the claimable balance of each token rather than the total reward payout
- Fixed waivePayoutTxs to properly waive multiple payouts
- claimPayoutTxs now queries the correct locked token balance.
- token amounts are now properly parsed into wei when moving tokens between pots / making payments.
- the correct token address is now passed to moveTokenTxs
- various refactorings
